### PR TITLE
Stop modal from closing if there is an error

### DIFF
--- a/src/Concerns/HasExcelImportAction.php
+++ b/src/Concerns/HasExcelImportAction.php
@@ -121,6 +121,9 @@ trait HasExcelImportAction
                 };
 
                 $notification->send();
+
+                // Stop the modal from closing if we have an error
+                $this->halt();
                 
                 return false;
             }


### PR DESCRIPTION
When there is an error, a notification is fired, but the modal closes. This means that to rectify any issues the user has to open the modal again, upload the file and fill out the form (if it has been defined).

Now, the action is halted if there is an error so that no data is lost in the modal form.